### PR TITLE
Testnet Support in Example

### DIFF
--- a/examples/csv/src/main.rs
+++ b/examples/csv/src/main.rs
@@ -24,6 +24,9 @@ struct Args {
     /// Check that the file exists and print simple metadata about the snapshot
     #[arg(short, long, default_value_t = false)]
     check: bool,
+    /// Whether this is a testnet (testnet3, testnet4, signet)
+    #[arg(short, long, default_value_t = false)]
+    testnet: bool,
 }
 
 fn main() -> Result<(), std::io::Error> {
@@ -32,7 +35,11 @@ fn main() -> Result<(), std::io::Error> {
     let mut stdout = std::io::stdout();
 
     let compute_addresses = if args.addresses {
-        ComputeAddresses::Yes(txoutset::Network::Bitcoin)
+        if args.testnet {
+            ComputeAddresses::Yes(txoutset::Network::Testnet)
+        } else {
+            ComputeAddresses::Yes(txoutset::Network::Bitcoin)
+        }
     } else {
         ComputeAddresses::No
     };

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,4 @@
+comment_width = 80
+imports_granularity = "Module"
+group_imports = "StdExternalCrate"
+wrap_comments = true

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,9 +12,8 @@ use std::io::{ErrorKind, Seek};
 use std::path::Path;
 
 use bitcoin::consensus::{Decodable, Encodable};
-use bitcoin::{Address, BlockHash, OutPoint, ScriptBuf};
-
 pub use bitcoin::Network;
+use bitcoin::{Address, BlockHash, OutPoint, ScriptBuf};
 
 pub mod amount;
 pub mod script;

--- a/src/var_int.rs
+++ b/src/var_int.rs
@@ -111,9 +111,6 @@ impl From<u8> for VarInt {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum Error {}
-
 #[cfg(test)]
 mod test {
     use super::*;


### PR DESCRIPTION
Prior to this change, all addresses were printed with mainnet prefixes. This adds a new command line argument to optionally set the network to testnet.