### PR TITLE
Bump Dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,11 +10,14 @@ license = "MIT"
 edition = "2021"
 
 [dependencies]
-bitcoin = "0.31.1"
+bitcoin.workspace = true
 thiserror = "2.0.17"
-log = "0.4.21"
+log = "0.4.28"
 
 [workspace]
 members = [
     "examples/*"
 ]
+
+[workspace.dependencies]
+bitcoin = "0.31.2"

--- a/examples/csv/Cargo.toml
+++ b/examples/csv/Cargo.toml
@@ -4,13 +4,13 @@ version = "0.2.1"
 edition = "2021"
 
 [dependencies]
-bitcoin = "0.31.1"
-env_logger = "0.11"
+bitcoin.workspace = true
+env_logger = "0.11.8"
 hex = "0.4.3"
 
 [dependencies.txoutset]
 path = "../../"
 
 [dependencies.clap]
-version = "4.5.1"
+version = "4.5.51"
 features = ["derive"]


### PR DESCRIPTION
Updates `bitcoin` to 0.31.2` and makes it a workspace dependency. Bumps other dependencies.