### PR TITLE
Update to Bitcoin 0.32.7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,4 +20,4 @@ members = [
 ]
 
 [workspace.dependencies]
-bitcoin = "0.31.2"
+bitcoin = "0.32.7"

--- a/src/amount.rs
+++ b/src/amount.rs
@@ -38,10 +38,10 @@ impl Amount {
 }
 
 impl Encodable for Amount {
-    fn consensus_encode<W: std::io::Write + ?Sized>(
+    fn consensus_encode<W: bitcoin::io::Write + ?Sized>(
         &self,
         writer: &mut W,
-    ) -> Result<usize, std::io::Error> {
+    ) -> Result<usize, bitcoin::io::Error> {
         let compressed = self.compress();
         let var_int = VarInt::from(compressed);
 
@@ -50,7 +50,7 @@ impl Encodable for Amount {
 }
 
 impl Decodable for Amount {
-    fn consensus_decode<R: std::io::Read + ?Sized>(
+    fn consensus_decode<R: bitcoin::io::Read + ?Sized>(
         reader: &mut R,
     ) -> Result<Self, bitcoin::consensus::encode::Error> {
         let var_int = VarInt::consensus_decode(reader)?;

--- a/src/compact_size.rs
+++ b/src/compact_size.rs
@@ -18,10 +18,10 @@ impl CompactSize {
 }
 
 impl Encodable for CompactSize {
-    fn consensus_encode<W: std::io::Write + ?Sized>(
+    fn consensus_encode<W: bitcoin::io::Write + ?Sized>(
         &self,
         writer: &mut W,
-    ) -> Result<usize, std::io::Error> {
+    ) -> Result<usize, bitcoin::io::Error> {
         if self.0 < 253 {
             let n = self.0 as u8;
             writer.write(&[n])
@@ -41,7 +41,7 @@ impl Encodable for CompactSize {
 }
 
 impl Decodable for CompactSize {
-    fn consensus_decode<R: std::io::Read + ?Sized>(
+    fn consensus_decode<R: bitcoin::io::Read + ?Sized>(
         reader: &mut R,
     ) -> Result<Self, bitcoin::consensus::encode::Error> {
         let size = reader.read_u8()?;

--- a/src/script.rs
+++ b/src/script.rs
@@ -21,7 +21,7 @@ impl Script {
 }
 
 impl Decodable for Script {
-    fn consensus_decode<R: std::io::Read + ?Sized>(reader: &mut R) -> Result<Self, Error> {
+    fn consensus_decode<R: bitcoin::io::Read + ?Sized>(reader: &mut R) -> Result<Self, Error> {
         let mut size = u64::from(VarInt::consensus_decode(reader)?) as usize;
 
         match size {

--- a/src/var_int.rs
+++ b/src/var_int.rs
@@ -34,10 +34,10 @@ impl VarInt {
 }
 
 impl Encodable for VarInt {
-    fn consensus_encode<W: std::io::Write + ?Sized>(
+    fn consensus_encode<W: bitcoin::io::Write + ?Sized>(
         &self,
         writer: &mut W,
-    ) -> Result<usize, std::io::Error> {
+    ) -> Result<usize, bitcoin::io::Error> {
         let mut num = self.0;
         let mut bytes = Vec::with_capacity((std::mem::size_of::<u64>() * 8).div_ceil(7));
 
@@ -58,7 +58,7 @@ impl Encodable for VarInt {
 }
 
 impl Decodable for VarInt {
-    fn consensus_decode<R: std::io::Read + ?Sized>(
+    fn consensus_decode<R: bitcoin::io::Read + ?Sized>(
         reader: &mut R,
     ) -> Result<Self, bitcoin::consensus::encode::Error> {
         let mut n: u64 = 0;


### PR DESCRIPTION
Alternative approach to #5 (thanks for the inspiration @liuchengxu).

I'm not super happy that the most recent version of the `bitcoin` library exposes a bunch of internal `io` traits. However, the `bitcoin_io::bridge` traits make it possible to work with normal `std::io` traits without too much fuss.

Closes #5 